### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported
+Public GitHub Pages site for Pixweave.
+
+## Report a vulnerability
+- Use **GitHub → Security → “Report a vulnerability”** (Private reporting).
+- Or email **support@pixweave.net** with subject `Security report`.
+- Include steps to reproduce, affected URL/file, and impact.
+
+## Do not
+- Do not open public issues with sensitive details.
+- Do not attempt to exfiltrate secrets. If you think you found any, stop and notify us.


### PR DESCRIPTION
Added security policy for Pixweave:
- contact for private reports: support@pixweave.net
- instructions to use Private vulnerability reporting
- warning: do not publish sensitive details in public Issues
No changes to code or build, only documentation.